### PR TITLE
Add segmented transport selector

### DIFF
--- a/form.html
+++ b/form.html
@@ -8,16 +8,53 @@
   <link rel="stylesheet" href="style.css">
 </head>
 <body>
-  <div id="step-age" class="step container active">
-    <label>Возраст ребёнка</label>
-    <input type="number" id="age" min="3" max="18" value="6">
-    <div id="ageError" class="error hidden">Возраст должен быть от 3 до 18 лет</div>
-    <button id="ageNext">Далее</button>
+  <div id="step-age" class="step active">
+    <div id="ageOverlay" class="overlay">
+      <div id="ageModal" class="age-modal">
+        <div class="dial-wrapper">
+          <button id="ageMinus" class="circle-btn">&#8722;</button>
+          <div id="dial" class="dial"></div>
+          <div id="selectedAge" class="selected-age">7</div>
+          <div id="agePreview" class="preview"><div>👶</div><div id="previewText">7 лет</div></div>
+          <button id="agePlus" class="circle-btn">+</button>
+        </div>
+        <input type="text" id="ageInput" class="age-input" value="7">
+        <div id="ageError" class="error hidden">От 3 до 18 лет</div>
+        <div class="hint">Возраст поможет подобрать оптимальную группу</div>
+        <button id="ageNext" disabled>Далее</button>
+      </div>
+    </div>
   </div>
   <div id="step-gender" class="step container">
     <label>Пол ребёнка</label>
-    <label><input type="radio" name="gender" value="boy"> Мальчик</label>
-    <label><input type="radio" name="gender" value="girl"> Девочка</label>
+    <div id="genderControl" class="gender-control">
+      <label class="gender-segment">
+        <input type="radio" name="gender" value="boy">
+        <svg class="icon" viewBox="0 0 24 24" aria-hidden="true">
+          <circle cx="12" cy="5" r="3" />
+          <path d="M9 22v-6H7l2-5h6l2 5h-2v6" />
+        </svg>
+        <span>Мальчик</span>
+      </label>
+      <label class="gender-segment">
+        <input type="radio" name="gender" value="girl">
+        <svg class="icon" viewBox="0 0 24 24" aria-hidden="true">
+          <circle cx="12" cy="5" r="3" />
+          <path d="M8 22v-4l4-6 4 6v4" />
+        </svg>
+        <span>Девочка</span>
+      </label>
+      <label class="gender-segment">
+        <input type="radio" name="gender" value="any">
+        <svg class="icon" viewBox="0 0 24 24" aria-hidden="true">
+          <circle cx="12" cy="5" r="3" />
+          <rect x="10" y="9" width="4" height="8" />
+          <path d="M10 17v4M14 17v4M8 12h8" />
+        </svg>
+        <span>Не важно</span>
+      </label>
+    </div>
+    <div id="genderError" class="error hidden">Пожалуйста, выберите пол ребёнка</div>
     <button id="genderNext" disabled>Далее</button>
   </div>
   <div id="step-address" class="step container">
@@ -26,15 +63,37 @@
     <button id="geo">Определить по GPS</button>
     <button id="addressNext">Далее</button>
   </div>
-  <div id="step-transport" class="step container">
+  <div id="step-transport" class="step">
     <label>Предпочтительный способ добраться</label>
-    <select id="transport">
-      <option value="" selected disabled>Выберите</option>
-      <option value="walk">Пешком</option>
-      <option value="car">На машине</option>
-      <option value="public">Общественным транспортом</option>
-    </select>
-    <div style="font-size:0.9rem">Этот выбор повлияет на расчёт маршрутов и времени в дальнейшем</div>
+    <div id="transportControl" class="transport-control">
+      <label class="transport-segment">
+        <input type="radio" name="transport" value="walk">
+        <svg class="icon" viewBox="0 0 24 24" aria-hidden="true">
+          <path d="M12 2a2 2 0 110 4 2 2 0 010-4zM10 22v-6l-2-4 4-2 2 2h2l3 5v5" />
+        </svg>
+        <span>Пешком</span>
+      </label>
+      <label class="transport-segment">
+        <input type="radio" name="transport" value="car">
+        <svg class="icon" viewBox="0 0 24 24" aria-hidden="true">
+          <path d="M3 13l2-5h14l2 5M5 13v5h2v-2h10v2h2v-5" />
+          <circle cx="7" cy="18" r="1.5" />
+          <circle cx="17" cy="18" r="1.5" />
+        </svg>
+        <span>На машине</span>
+      </label>
+      <label class="transport-segment">
+        <input type="radio" name="transport" value="public">
+        <svg class="icon" viewBox="0 0 24 24" aria-hidden="true">
+          <rect x="3" y="5" width="18" height="12" rx="2" />
+          <path d="M3 13h18M8 18v2M16 18v2" />
+        </svg>
+        <span>Общественный</span>
+      </label>
+      <div id="transportAccent" class="accent"></div>
+    </div>
+    <div id="transportError" class="error hidden">Пожалуйста, выберите способ перемещения</div>
+    <div class="hint">Этот выбор повлияет на расчёт маршрутов и времени в дальнейшем</div>
     <button id="transportNext" disabled>Далее</button>
   </div>
   <div id="step-range" class="step container">
@@ -74,39 +133,139 @@
     }
     showStep(current);
 
-    // Age validation
-    const ageInput = document.getElementById('age');
-    const ageError = document.getElementById('ageError');
-    const ageNext = document.getElementById('ageNext');
-    function validateAge(){
-      const v = parseInt(ageInput.value,10);
-      if(isNaN(v) || v<3 || v>18){
-        ageError.classList.remove('hidden');
-        ageNext.disabled = true;
-      } else {
-        ageError.classList.add('hidden');
-        ageNext.disabled = false;
+    // Age selector
+    const ageInput = document.getElementById("ageInput");
+    const ageError = document.getElementById("ageError");
+    const ageNext = document.getElementById("ageNext");
+    const dial = document.getElementById("dial");
+    const selectedAgeEl = document.getElementById("selectedAge");
+    const ageMinus = document.getElementById("ageMinus");
+    const agePlus = document.getElementById("agePlus");
+    const previewText = document.getElementById("previewText");
+    const stepDeg = 360/16;
+    let age = 7;
+
+    function createDial(){
+      for(let i=3;i<=18;i++){
+        const d=document.createElement("div");
+        d.className="dial-number";
+        if(i>=6 && i<=8) d.classList.add("recommended");
+        d.dataset.age=i;
+        dial.appendChild(d);
       }
     }
-    ageInput.addEventListener('input', validateAge);
-    validateAge();
-    ageNext.onclick = () => { current++; showStep(current); };
 
-    // Gender
-    const genderRadios = document.querySelectorAll('input[name="gender"]');
+    function updateDial(){
+      dial.style.transform = "rotate(" + (-(age-3)*stepDeg) + "deg)";
+      Array.from(dial.children).forEach(el=>{
+        const v=parseInt(el.dataset.age,10);
+        const angle=(v-3)*stepDeg;
+        const active=v===age;
+        const scale=active?1.4:1;
+        el.style.transform="rotate("+angle+"deg) translate(0,-80px) rotate("+(-angle)+"deg) scale("+scale+")";
+        el.style.color=active?"var(--tg-theme-button-color, #3390ec)":"";
+      });
+      selectedAgeEl.textContent=age;
+      ageInput.value=age;
+      previewText.textContent=age+" лет";
+      validateAge();
+    }
+
+    function validateAge(){
+      const v=parseInt(ageInput.value,10);
+      if(isNaN(v)||v<3||v>18){
+        ageError.classList.remove("hidden");
+        ageNext.disabled=true;
+      }else{
+        ageError.classList.add("hidden");
+        ageNext.disabled=false;
+      }
+    }
+
+    ageInput.addEventListener("input",()=>{
+      const v=parseInt(ageInput.value,10);
+      if(!isNaN(v)){ age=Math.max(3,Math.min(18,v)); }
+      updateDial();
+    });
+    ageMinus.onclick=()=>{ if(age>3){ age--; updateDial(); } };
+    agePlus.onclick=()=>{ if(age<18){ age++; updateDial(); } };
+    let startY;
+    dial.addEventListener("pointerdown",e=>{ startY=e.clientY; });
+    dial.addEventListener("pointerup",e=>{ const diff=e.clientY-startY; if(Math.abs(diff)>30){ if(diff>0&&age>3) age--; if(diff<0&&age<18) age++; updateDial(); } });
+    createDial();
+    updateDial();
+    ageNext.onclick=()=>{ current++; showStep(current); };
+
+
+    // Gender segmented control
+    const genderInputs = document.querySelectorAll('input[name="gender"]');
+    const genderSegments = document.querySelectorAll('.gender-segment');
+    const genderControl = document.getElementById('genderControl');
+    const genderError = document.getElementById('genderError');
     const genderNext = document.getElementById('genderNext');
-    genderRadios.forEach(r=> r.onchange = ()=>{ genderNext.disabled = false; });
-    genderNext.onclick = () => { current++; showStep(current); };
+    genderInputs.forEach(input => {
+      input.addEventListener('change', () => {
+        genderSegments.forEach(s => s.classList.remove('selected'));
+        input.parentElement.classList.add('selected','pulse');
+        setTimeout(()=>input.parentElement.classList.remove('pulse'),150);
+        genderNext.disabled = false;
+        genderError.classList.add('hidden');
+        genderControl.classList.remove('error');
+      });
+    });
+    genderNext.onclick = () => {
+      const chosen = document.querySelector('input[name="gender"]:checked');
+      if(!chosen){
+        genderError.classList.remove('hidden');
+        genderControl.classList.add('error');
+      } else {
+        current++; showStep(current);
+      }
+    };
 
     // Address
     document.getElementById('geo').onclick = () => tg.requestLocation();
     document.getElementById('addressNext').onclick = () => { current++; showStep(current); };
 
-    // Transport
-    const transport = document.getElementById('transport');
+    // Transport segmented control
+    const transportInputs = document.querySelectorAll('input[name="transport"]');
+    const transportSegments = document.querySelectorAll('.transport-segment');
+    const transportAccent = document.getElementById('transportAccent');
+    const transportControl = document.getElementById('transportControl');
+    const transportError = document.getElementById('transportError');
     const transportNext = document.getElementById('transportNext');
-    transport.onchange = () => { transportNext.disabled = !transport.value; };
-    transportNext.onclick = () => { current++; showStep(current); };
+
+    function moveAccent(el){
+      transportAccent.style.width = el.offsetWidth + 'px';
+      transportAccent.style.left = el.offsetLeft + 'px';
+    }
+
+    moveAccent(transportSegments[0]);
+
+    transportInputs.forEach(input => {
+      input.addEventListener('change', () => {
+        transportSegments.forEach(s => s.classList.remove('selected'));
+        const seg = input.parentElement;
+        seg.classList.add('selected','jump');
+        moveAccent(seg);
+        transportAccent.style.opacity = '1';
+        setTimeout(()=>seg.classList.remove('jump'),100);
+        transportNext.disabled = false;
+        transportError.classList.add('hidden');
+        transportControl.classList.remove('error');
+      });
+    });
+
+    transportNext.onclick = () => {
+      const chosen = document.querySelector('input[name="transport"]:checked');
+      if(!chosen){
+        transportError.classList.remove('hidden');
+        transportControl.classList.add('error');
+        setTimeout(()=>transportControl.classList.remove('error'),200);
+      } else {
+        current++; showStep(current);
+      }
+    };
 
     // Range
     const timeRange = document.getElementById('time');

--- a/style.css
+++ b/style.css
@@ -163,3 +163,201 @@ button:active {
 @keyframes swipe-left {
   to { transform: translateX(-120%) rotate(-15deg); opacity: 0; }
 }
+/* Age selector modal */
+.overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.4);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  animation: fade 0.2s ease;
+}
+.age-modal {
+  background: var(--tg-theme-bg-color, #fff);
+  padding: 1rem;
+  border-radius: 1rem;
+  width: 280px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1rem;
+  animation: scale 0.2s ease;
+}
+@keyframes scale {
+  from { transform: scale(0.9); opacity: 0; }
+  to { transform: scale(1); opacity: 1; }
+}
+.dial-wrapper {
+  position: relative;
+  width: 200px;
+  height: 200px;
+}
+.dial {
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  border-radius: 50%;
+  transition: transform 0.3s cubic-bezier(.33,1,.68,1);
+}
+.dial-number {
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  transform-origin: 0 -80px;
+  color: var(--tg-theme-hint-color, #888);
+  transition: transform 0.2s, color 0.2s;
+  font-size: 1rem;
+}
+.dial-number.recommended {
+  border: 1px solid var(--tg-theme-button-color, #3390ec);
+  border-radius: 50%;
+  padding: 2px 4px;
+}
+.circle-btn {
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  border: none;
+  background: var(--tg-theme-button-color, #3390ec);
+  color: var(--tg-theme-button-text-color, #fff);
+  font-size: 1.2rem;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+.age-input {
+  width: 80px;
+  text-align: center;
+}
+.preview {
+  position: absolute;
+  right: -70px;
+  top: 50%;
+  transform: translateY(-50%);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  font-size: 0.9rem;
+}
+.selected-age {
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  transform: translate(-50%, -50%);
+  font-size: 2rem;
+  color: var(--tg-theme-button-color, #3390ec);
+}
+.hint { font-size: 0.9rem; color: var(--tg-theme-hint-color, #666); }
+
+/* Gender segmented control */
+.gender-control {
+  display: flex;
+  gap: 0.5rem;
+  width: 80%;
+  justify-content: center;
+}
+.gender-segment {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 0.5rem;
+  background: #F5F5F5;
+  border-radius: 8px;
+  cursor: pointer;
+  color: #555;
+  transition: background-color 0.2s, color 0.2s, transform 0.15s;
+}
+.gender-segment input { display: none; }
+.gender-segment .icon {
+  width: 40px;
+  height: 40px;
+  margin-bottom: 0.25rem;
+  fill: currentColor;
+}
+.gender-segment:hover,
+.gender-segment:focus-within {
+  border: 2px solid var(--tg-theme-button-color, #3390ec);
+  box-shadow: 0 0 8px rgba(0,0,0,0.1);
+}
+.gender-segment.selected {
+  background: var(--tg-theme-button-color, #3390ec);
+  color: var(--tg-theme-button-text-color, #fff);
+}
+.gender-control.error {
+  border: 2px solid red;
+  border-radius: 8px;
+  padding: 0.5rem;
+}
+.pulse {
+  animation: pulse 150ms;
+}
+@keyframes pulse {
+  0% { transform: scale(1); }
+  50% { transform: scale(1.05); }
+  100% { transform: scale(1); }
+}
+
+/* Transport segmented control */
+.transport-control {
+  position: relative;
+  display: flex;
+  gap: 8px;
+  padding: 1rem;
+  background: rgba(255, 255, 255, 0.8);
+  border-radius: 12px;
+  box-shadow: 0 0 8px rgba(0,0,0,0.1);
+  margin-top: -2rem;
+}
+.transport-segment {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 0.5rem 0;
+  background: #F0F0F0;
+  border-radius: 8px;
+  color: #888;
+  cursor: pointer;
+  transition: background-color 0.2s ease, color 0.2s ease, transform 0.1s;
+}
+.transport-segment input { display: none; }
+.transport-segment .icon {
+  width: 36px;
+  height: 36px;
+  margin-bottom: 0.25rem;
+  fill: currentColor;
+}
+.transport-segment:hover,
+.transport-segment:focus-within {
+  background: #fff;
+  border: 2px solid var(--tg-theme-button-color, #3390ec);
+  box-shadow: 0 0 12px rgba(0,0,0,0.15);
+}
+.transport-segment.selected {
+  background: var(--tg-theme-button-color, #3390ec);
+  color: var(--tg-theme-button-text-color, #fff);
+}
+.transport-segment.jump {
+  animation: jump 100ms;
+}
+.transport-control.error {
+  animation: pulse 200ms;
+}
+.accent {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  height: 3px;
+  background: var(--tg-theme-button-color, #3390ec);
+  opacity: 0;
+  border-radius: 2px;
+  transition: left 0.2s ease, width 0.2s ease, opacity 0.2s ease;
+  pointer-events: none;
+}
+@keyframes jump {
+  0% { transform: translateY(0); }
+  50% { transform: translateY(-4px); }
+  100% { transform: translateY(0); }
+}


### PR DESCRIPTION
## Summary
- switch transport selection to animated segmented control with icons
- style transport segments with hover and selected states
- move floating accent bar under chosen option and validate selection

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_686cd82531108322932c1ba1cff0c4f7