### PR TITLE
Fix age selector UI and simplify interests

### DIFF
--- a/form.html
+++ b/form.html
@@ -105,13 +105,13 @@
   </div>
   <div id="step-interests" class="step container">
     <label>Выберите интересующие направления</label>
-    <div id="selected" class="selected"></div>
     <div class="carousel"><div id="discTrack" class="track"></div></div>
     <div class="swipe-buttons">
       <button id="likeBtn">Мне интересно</button>
       <button id="skipBtn">Пропустить</button>
     </div>
-    <button id="finish" disabled>Подобрать</button>
+    <div id="selected" class="selected"></div>
+    <button id="finish" class="finish-btn" disabled>Подобрать</button>
   </div>
   <script>
 
@@ -148,6 +148,7 @@
         const d=document.createElement("div");
         d.className="dial-number";
         if(i>=6 && i<=8) d.classList.add("recommended");
+        d.textContent = i;
         d.dataset.age=i;
         dial.appendChild(d);
       }
@@ -291,7 +292,6 @@
       card.className = "disc-card";
       card.dataset.value = d.id;
       card.innerHTML = `<div class="icon">${d.icon}</div><div>${d.title}</div><div class="tagline">${d.tag}</div>`;
-      attachSwipe(card);
       track.appendChild(card);
     });
     function updateButtons(){ finish.disabled = chosen.length === 0; }
@@ -312,11 +312,6 @@
     }
     likeBtn.onclick = () => handleChoice(true);
     skipBtn.onclick = () => handleChoice(false);
-    function attachSwipe(el){
-      let startX;
-      el.addEventListener("pointerdown", e => { startX = e.clientX; });
-      el.addEventListener("pointerup", e => { const diff = e.clientX - startX; if(Math.abs(diff) > 50){ handleChoice(diff > 0); } });
-    }
     updateButtons();
     finish.onclick = () => location.href = "loading.html";
 

--- a/style.css
+++ b/style.css
@@ -127,11 +127,22 @@ button:active {
 .swipe-buttons {
   display: flex;
   gap: 1rem;
+  width: 100%;
+}
+.swipe-buttons button {
+  flex: 1;
+}
+.finish-btn {
+  margin-top: 1rem;
+  background: #FF9800;
+  color: #fff;
+  width: 100%;
 }
 .selected {
   display: flex;
   gap: 0.5rem;
   flex-wrap: wrap;
+  margin-top: 0.5rem;
 }
 .selected .chip {
   background: var(--tg-theme-secondary-bg-color, #ddd);
@@ -225,6 +236,9 @@ button:active {
   display: flex;
   justify-content: center;
   align-items: center;
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
 }
 .age-input {
   width: 80px;
@@ -248,6 +262,8 @@ button:active {
   font-size: 2rem;
   color: var(--tg-theme-button-color, #3390ec);
 }
+.dial-wrapper #ageMinus { left: -20px; }
+.dial-wrapper #agePlus { right: -20px; }
 .hint { font-size: 0.9rem; color: var(--tg-theme-hint-color, #666); }
 
 /* Gender segmented control */


### PR DESCRIPTION
## Summary
- show numbers on the age selector wheel and position controls
- reorder interests step layout and disable swipe handling
- style "Подобрать" button differently

## Testing
- `npm test` *(fails: Could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686ce9fa8aa88322acc8ae2693c650ad