### PR TITLE
Fix age dial UI and interests card layout

### DIFF
--- a/form.html
+++ b/form.html
@@ -15,8 +15,7 @@
         <div class="dial-wrapper">
           <button id="ageMinus" class="circle-btn">&#8722;</button>
           <div id="dial" class="dial"></div>
-          <div id="selectedAge" class="selected-age">7</div>
-          <div id="agePreview" class="preview"><div>👶</div><div id="previewText">7 лет</div></div>
+          <div id="selectedAge" class="selected-age">7 лет</div>
           <button id="agePlus" class="circle-btn">+</button>
         </div>
         <input type="text" id="ageInput" class="age-input" value="7">
@@ -139,15 +138,19 @@
     const selectedAgeEl = document.getElementById("selectedAge");
     const ageMinus = document.getElementById("ageMinus");
     const agePlus = document.getElementById("agePlus");
-    const previewText = document.getElementById("previewText");
     const stepDeg = 360/16;
     let age = 7;
+
+    function pluralAge(n){
+      if(n % 10 === 1 && n % 100 !== 11) return 'год';
+      if([2,3,4].includes(n % 10) && ![12,13,14].includes(n % 100)) return 'года';
+      return 'лет';
+    }
 
     function createDial(){
       for(let i=3;i<=18;i++){
         const d=document.createElement("div");
         d.className="dial-number";
-        if(i>=6 && i<=8) d.classList.add("recommended");
         d.textContent = i;
         d.dataset.age=i;
         dial.appendChild(d);
@@ -155,18 +158,18 @@
     }
 
     function updateDial(){
-      dial.style.transform = "rotate(" + (-(age-3)*stepDeg) + "deg)";
+      const dialRot = -(age-3)*stepDeg;
+      dial.style.transform = "rotate(" + dialRot + "deg)";
       Array.from(dial.children).forEach(el=>{
         const v=parseInt(el.dataset.age,10);
         const angle=(v-3)*stepDeg;
         const active=v===age;
         const scale=active?1.4:1;
-        el.style.transform="rotate("+angle+"deg) translate(0,-80px) rotate("+(-angle)+"deg) scale("+scale+")";
+        el.style.transform="rotate("+angle+"deg) translate(0,-80px) rotate("+(-angle-dialRot)+"deg) scale("+scale+")";
         el.style.color=active?"var(--tg-theme-button-color, #3390ec)":"";
       });
-      selectedAgeEl.textContent=age;
+      selectedAgeEl.textContent = age + ' ' + pluralAge(age);
       ageInput.value=age;
-      previewText.textContent=age+" лет";
       validateAge();
     }
 

--- a/style.css
+++ b/style.css
@@ -49,6 +49,11 @@ button:active {
 .container input[type="range"] {
   width: 100%;
 }
+input[type="checkbox"] {
+  width: 1.2rem;
+  height: 1.2rem;
+  accent-color: var(--tg-theme-button-color, #3390ec);
+}
 
 .hidden { display: none; }
 .error { color: red; font-size: 0.9rem; }
@@ -107,8 +112,8 @@ button:active {
 }
 .disc-card {
   position: relative;
-  flex: 0 0 70%;
-  margin-right: 5%;
+  flex: 0 0 100%;
+  margin-right: 0;
   background: var(--tg-theme-secondary-bg-color, #fff);
   border-radius: 0.75rem;
   padding: 1rem;
@@ -220,11 +225,6 @@ button:active {
   transition: transform 0.2s, color 0.2s;
   font-size: 1rem;
 }
-.dial-number.recommended {
-  border: 1px solid var(--tg-theme-button-color, #3390ec);
-  border-radius: 50%;
-  padding: 2px 4px;
-}
 .circle-btn {
   width: 40px;
   height: 40px;
@@ -242,17 +242,12 @@ button:active {
 }
 .age-input {
   width: 80px;
+  padding: 0.6rem;
   text-align: center;
-}
-.preview {
-  position: absolute;
-  right: -70px;
-  top: 50%;
-  transform: translateY(-50%);
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  font-size: 0.9rem;
+  border-radius: 0.5rem;
+  border: 1px solid var(--tg-theme-hint-color, #ccc);
+  font-size: 1rem;
+  box-sizing: border-box;
 }
 .selected-age {
   position: absolute;
@@ -262,8 +257,8 @@ button:active {
   font-size: 2rem;
   color: var(--tg-theme-button-color, #3390ec);
 }
-.dial-wrapper #ageMinus { left: -20px; }
-.dial-wrapper #agePlus { right: -20px; }
+.dial-wrapper #ageMinus { left: -40px; }
+.dial-wrapper #agePlus { right: -40px; }
 .hint { font-size: 0.9rem; color: var(--tg-theme-hint-color, #666); }
 
 /* Gender segmented control */


### PR DESCRIPTION
## Summary
- remove recommended age highlight and preview block
- keep numbers upright as dial rotates
- pluralize year word next to selected age
- adjust buttons and input styling
- prevent partial peek of the next interest card

## Testing
- `npm --version`


------
https://chatgpt.com/codex/tasks/task_e_686cf74edafc8322a79caf7972a5a52d