### PR TITLE
Fix tg-init load timing

### DIFF
--- a/www/club.html
+++ b/www/club.html
@@ -5,8 +5,8 @@
   <title>КлубоГид - клуб</title>
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <script src="https://telegram.org/js/telegram-web-app.js"></script>
-  <script src="tg-init.js"></script>
-  <link rel="stylesheet" href="style.css">
+  <script src="./tg-init.js" defer></script>
+  <link rel="stylesheet" href="./style.css">
 </head>
 <body>
   <div class="container">

--- a/www/form.html
+++ b/www/form.html
@@ -5,8 +5,8 @@
   <title>КлубоГид - анкета</title>
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <script src="https://telegram.org/js/telegram-web-app.js"></script>
-  <script src="tg-init.js"></script>
-  <link rel="stylesheet" href="style.css">
+  <script src="./tg-init.js" defer></script>
+  <link rel="stylesheet" href="./style.css">
 </head>
 <body>
   <div id="step-age" class="step active">

--- a/www/index.html
+++ b/www/index.html
@@ -5,8 +5,8 @@
   <title>КлубоГид</title>
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <script src="https://telegram.org/js/telegram-web-app.js"></script>
-  <script src="tg-init.js"></script>
-  <link rel="stylesheet" href="style.css">
+  <script src="./tg-init.js" defer></script>
+  <link rel="stylesheet" href="./style.css">
 </head>
 <body>
   <div class="container">

--- a/www/loading.html
+++ b/www/loading.html
@@ -5,8 +5,8 @@
   <title>КлубоГид - поиск</title>
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <script src="https://telegram.org/js/telegram-web-app.js"></script>
-  <script src="tg-init.js"></script>
-  <link rel="stylesheet" href="style.css">
+  <script src="./tg-init.js" defer></script>
+  <link rel="stylesheet" href="./style.css">
 </head>
 <body>
   <div class="container">

--- a/www/results.html
+++ b/www/results.html
@@ -5,8 +5,8 @@
   <title>КлубоГид - результаты</title>
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <script src="https://telegram.org/js/telegram-web-app.js"></script>
-  <script src="tg-init.js"></script>
-  <link rel="stylesheet" href="style.css">
+  <script src="./tg-init.js" defer></script>
+  <link rel="stylesheet" href="./style.css">
 </head>
 <body>
   <div class="container">

--- a/www/tg-init.js
+++ b/www/tg-init.js
@@ -1,11 +1,11 @@
-(() => {
+window.addEventListener('DOMContentLoaded', () => {
   const tg = window.Telegram.WebApp;
   if (!tg) return;
   tg.ready();
   tg.expand();
 
   const applyTheme = () => {
-    document.body.style.background = tg.themeParams.bg_color || '#f5f5f5';
+    document.body.style.background = tg.themeParams?.bg_color || '#f5f5f5';
   };
 
   tg.onEvent('themeChanged', applyTheme);
@@ -19,4 +19,4 @@
       // ignore if back button not supported
     }
   }
-})();
+});

--- a/www/welcome.html
+++ b/www/welcome.html
@@ -5,8 +5,8 @@
   <title>КлубоГид - о приложении</title>
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <script src="https://telegram.org/js/telegram-web-app.js"></script>
-  <script src="tg-init.js"></script>
-  <link rel="stylesheet" href="style.css">
+  <script src="./tg-init.js" defer></script>
+  <link rel="stylesheet" href="./style.css">
 </head>
 <body>
   <div class="container">


### PR DESCRIPTION
## Summary
- defer tg-init.js in every HTML file
- run tg-init.js after DOMContentLoaded
- default page background when theme params are missing
- use `./` relative paths for style.css and tg-init.js

## Testing
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_686d5eb130408322b3ddcdbd01e7a254