### PR TITLE
Expose global tg object for forms

### DIFF
--- a/www/form.html
+++ b/www/form.html
@@ -247,7 +247,7 @@
     });
 
     // Address
-    document.getElementById('geo').addEventListener('pointerup', () => tg.requestLocation());
+    document.getElementById('geo').addEventListener('pointerup', () => window.tg.requestLocation());
     document.getElementById('addressNext').addEventListener('pointerup', () => {
       current++; showStep(current);
     });

--- a/www/tg-init.js
+++ b/www/tg-init.js
@@ -1,5 +1,6 @@
 window.addEventListener('DOMContentLoaded', () => {
   const tg = window.Telegram.WebApp;
+  window.tg = tg;
   if (!tg) return;
   tg.ready();
   tg.expand();


### PR DESCRIPTION
## Summary
- expose the `Telegram.WebApp` object globally in `tg-init.js`
- update form page to call `window.tg.requestLocation()`

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686d7fda38b88322aa771936e0e6c603