### PR TITLE
Improve accessibility in static pages

### DIFF
--- a/www/form.html
+++ b/www/form.html
@@ -32,6 +32,7 @@
       <label class="gender-segment">
         <input type="radio" name="gender" value="boy">
         <svg class="icon" viewBox="0 0 24 24" aria-hidden="true">
+          <title>Мальчик</title>
           <circle cx="12" cy="5" r="3" />
           <path d="M9 22v-6H7l2-5h6l2 5h-2v6" />
         </svg>
@@ -40,6 +41,7 @@
       <label class="gender-segment">
         <input type="radio" name="gender" value="girl">
         <svg class="icon" viewBox="0 0 24 24" aria-hidden="true">
+          <title>Девочка</title>
           <circle cx="12" cy="5" r="3" />
           <path d="M8 22v-4l4-6 4 6v4" />
         </svg>
@@ -48,6 +50,7 @@
       <label class="gender-segment">
         <input type="radio" name="gender" value="any">
         <svg class="icon" viewBox="0 0 24 24" aria-hidden="true">
+          <title>Не важно</title>
           <circle cx="12" cy="5" r="3" />
           <rect x="10" y="9" width="4" height="8" />
           <path d="M10 17v4M14 17v4M8 12h8" />
@@ -70,6 +73,7 @@
       <label class="transport-segment">
         <input type="radio" name="transport" value="walk">
         <svg class="icon" viewBox="0 0 24 24" aria-hidden="true">
+          <title>Пешком</title>
           <path d="M12 2a2 2 0 110 4 2 2 0 010-4zM10 22v-6l-2-4 4-2 2 2h2l3 5v5" />
         </svg>
         <span>Пешком</span>
@@ -77,6 +81,7 @@
       <label class="transport-segment">
         <input type="radio" name="transport" value="car">
         <svg class="icon" viewBox="0 0 24 24" aria-hidden="true">
+          <title>На машине</title>
           <path d="M3 13l2-5h14l2 5M5 13v5h2v-2h10v2h2v-5" />
           <circle cx="7" cy="18" r="1.5" />
           <circle cx="17" cy="18" r="1.5" />
@@ -86,6 +91,7 @@
       <label class="transport-segment">
         <input type="radio" name="transport" value="public">
         <svg class="icon" viewBox="0 0 24 24" aria-hidden="true">
+          <title>Общественный</title>
           <rect x="3" y="5" width="18" height="12" rx="2" />
           <path d="M3 13h18M8 18v2M16 18v2" />
         </svg>

--- a/www/index.html
+++ b/www/index.html
@@ -11,12 +11,7 @@
 </head>
 <body>
   <div class="container">
-    <button id="start">Начать</button>
+    <a id="start" class="button" href="welcome.html" role="button" aria-label="Начать">Начать</a>
   </div>
-  <script>
-    document.getElementById('start').addEventListener('pointerup', () => {
-      location.href = 'welcome.html';
-    });
-  </script>
 </body>
 </html>

--- a/www/results.html
+++ b/www/results.html
@@ -13,18 +13,11 @@
   <div class="container">
     <h2>Подходящие клубы</h2>
     <div class="cards">
-      <div class="card" data-club="itkids">Клуб программирования "IT Kids"</div>
-      <div class="card" data-club="forte">Школа музыки "Форте"</div>
-      <div class="card" data-club="athlete">Спортивная секция "Юный атлет"</div>
+      <a class="card" href="club.html?club=itkids" role="button" aria-label="Клуб программирования IT Kids">Клуб программирования "IT Kids"</a>
+      <a class="card" href="club.html?club=forte" role="button" aria-label="Школа музыки Форте">Школа музыки "Форте"</a>
+      <a class="card" href="club.html?club=athlete" role="button" aria-label="Спортивная секция Юный атлет">Спортивная секция "Юный атлет"</a>
     </div>
   </div>
-  <script>
-    document.querySelectorAll('.card').forEach(card => {
-      card.addEventListener('pointerup', () => {
-        location.href = 'club.html?club=' + card.dataset.club;
-      });
-    });
-  </script>
 </body>
 </html>
 

--- a/www/style.css
+++ b/www/style.css
@@ -23,7 +23,7 @@ body {
   gap: 1rem;
 }
 
-button {
+button, .button {
   padding: 0.8rem 1.6rem;
   font-size: 1rem;
   border-radius: 0.8rem;
@@ -32,8 +32,10 @@ button {
   color: var(--tg-theme-button-text-color, #fff);
   cursor: pointer;
   transition: background 0.2s;
+  text-decoration: none;
+  display: inline-block;
 }
-button:active {
+button:active, .button:active {
   background: var(--tg-theme-button-color, #2a76c3);
 }
 .container input[type="text"],
@@ -88,6 +90,9 @@ input[type="checkbox"] {
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
   width: 100%;
   cursor: pointer;
+  text-decoration: none;
+  color: inherit;
+  display: block;
 }
 
 .step {


### PR DESCRIPTION
## Summary
- convert navigation to `<a>` links and add ARIA roles
- make button styles reusable
- allow card links to navigate directly
- add titles to SVG icons for screen readers

## Testing
- `npm test` *(fails: package.json missing)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_686d7fddf87c832290c40af3d8738c91