### PR TITLE
Update container width and modals

### DIFF
--- a/www/style.css
+++ b/www/style.css
@@ -15,7 +15,7 @@ body {
 /* container for centered content */
 .container {
   width: 100%;
-  max-width: 320px;
+  max-width: clamp(320px, 100%, 480px);
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -194,8 +194,8 @@ input[type="checkbox"] {
   background: var(--tg-theme-bg-color, #fff);
   padding: 1rem;
   border-radius: 1rem;
-  width: 100vw;
-  max-width: 320px;
+  width: 100%;
+  max-width: clamp(320px, 100%, 480px);
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -207,8 +207,8 @@ input[type="checkbox"] {
   background: var(--tg-theme-bg-color, #fff);
   padding: 1rem;
   border-radius: 1rem;
-  width: 100vw;
-  max-width: 320px;
+  width: 100%;
+  max-width: clamp(320px, 100%, 480px);
   display: flex;
   flex-direction: column;
   align-items: center;


### PR DESCRIPTION
## Summary
- widen `.container` to a responsive `clamp` with 480px cap
- match `.age-modal` and `.time-modal` widths to the new maximum

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_686d7fdf65508322ada12fb67a464ee2