### PR TITLE
Add welcome start page

### DIFF
--- a/client/src/application/router.ts
+++ b/client/src/application/router.ts
@@ -1,5 +1,6 @@
 import { type RouteRecordRaw, createRouter, createWebHistory } from 'vue-router'
 import Home from '@/presentation/screens/Home.vue'
+import Start from '@/presentation/screens/Start.vue'
 import Hotel from '@/presentation/screens/Hotel.vue'
 import Room from '@/presentation/screens/Room.vue'
 import Location from '@/presentation/screens/Location.vue'
@@ -7,6 +8,14 @@ import Location from '@/presentation/screens/Location.vue'
 const routes: RouteRecordRaw[] = [
   {
     path: '/',
+    component: Start,
+  },
+  {
+    path: '/start',
+    component: Start,
+  },
+  {
+    path: '/home',
     component: Home,
   },
   {

--- a/client/src/presentation/screens/Hotel.vue
+++ b/client/src/presentation/screens/Hotel.vue
@@ -98,7 +98,7 @@ const easterEgg = {
 
 onMounted(() => {
   showBackButton(() => {
-    void router.push('/')
+    void router.push('/home')
   })
 
   easterEgg.start()

--- a/client/src/presentation/screens/Location.vue
+++ b/client/src/presentation/screens/Location.vue
@@ -67,7 +67,7 @@ onMounted(() => {
   showMainButton('Select', () => {
     setCity(selectedId.value)
 
-    void router.push('/')
+    void router.push('/home')
   })
 
   showBackButton(() => {

--- a/client/src/presentation/screens/Start.vue
+++ b/client/src/presentation/screens/Start.vue
@@ -1,0 +1,46 @@
+<script setup lang="ts">
+import { Placeholder, Sections, Section } from '@/presentation/components'
+import { useTelegram } from '@/application/services'
+import { useRouter } from 'vue-router'
+import { onMounted, onBeforeUnmount } from 'vue'
+
+const { showMainButton, hideMainButton } = useTelegram()
+const router = useRouter()
+
+function start(): void {
+  void router.push('/home')
+}
+
+onMounted(() => {
+  showMainButton('Начать', start)
+})
+
+onBeforeUnmount(() => {
+  hideMainButton()
+})
+</script>
+
+<template>
+  <div class="start-page">
+    <Sections>
+      <Section>
+        <Placeholder
+          title="Добро пожаловать"
+          caption="Этот сервис позволяет подобрать удобные клубы поблизости"
+        >
+          <template #picture>
+            <img src="/telebook.svg" alt="logo" width="100" />
+          </template>
+        </Placeholder>
+      </Section>
+    </Sections>
+  </div>
+</template>
+
+<style scoped>
+.start-page {
+  display: flex;
+  flex-direction: column;
+  min-height: 100%;
+}
+</style>


### PR DESCRIPTION
## Summary
- introduce Start page with intro text and start button
- route '/' and '/start' to Start page
- move existing home to `/home`
- update back buttons to redirect to `/home`

## Testing
- `yarn lint` *(fails: project missing lockfile)*
- `yarn build` *(fails: project not installed)*

------
https://chatgpt.com/codex/tasks/task_e_687544143408832289e059ef1c47aca8