### PR TITLE
Add start page

### DIFF
--- a/client/src/application/router.ts
+++ b/client/src/application/router.ts
@@ -1,5 +1,6 @@
 import { type RouteRecordRaw, createRouter, createWebHistory } from 'vue-router'
 import Home from '@/presentation/screens/Home.vue'
+import Start from '@/presentation/screens/Start.vue'
 import Hotel from '@/presentation/screens/Hotel.vue'
 import Room from '@/presentation/screens/Room.vue'
 import Location from '@/presentation/screens/Location.vue'
@@ -7,6 +8,10 @@ import Location from '@/presentation/screens/Location.vue'
 const routes: RouteRecordRaw[] = [
   {
     path: '/',
+    component: Start,
+  },
+  {
+    path: '/home',
     component: Home,
   },
   {

--- a/client/src/presentation/screens/Hotel.vue
+++ b/client/src/presentation/screens/Hotel.vue
@@ -98,7 +98,7 @@ const easterEgg = {
 
 onMounted(() => {
   showBackButton(() => {
-    void router.push('/')
+    void router.push('/home')
   })
 
   easterEgg.start()

--- a/client/src/presentation/screens/Location.vue
+++ b/client/src/presentation/screens/Location.vue
@@ -67,7 +67,7 @@ onMounted(() => {
   showMainButton('Select', () => {
     setCity(selectedId.value)
 
-    void router.push('/')
+    void router.push('/home')
   })
 
   showBackButton(() => {

--- a/client/src/presentation/screens/Start.vue
+++ b/client/src/presentation/screens/Start.vue
@@ -1,0 +1,42 @@
+<script setup lang="ts">
+import { onMounted, onBeforeUnmount } from 'vue'
+import { useTelegram } from '@/application/services'
+import { useRouter } from 'vue-router'
+import { Placeholder } from '@/presentation/components'
+
+const { showMainButton, hideMainButton, expand } = useTelegram()
+const router = useRouter()
+
+onMounted(() => {
+  expand()
+  showMainButton('Начать', () => {
+    void router.push('/home')
+  })
+})
+
+onBeforeUnmount(() => {
+  hideMainButton()
+})
+</script>
+
+<template>
+  <div class="start-page">
+    <Placeholder
+      title="Club Agri"
+      caption="Этот сервис позволяет подобрать удобные клубы поблизости"
+    >
+      <template #picture>
+        <img src="/telebook.svg" aria-hidden="true" width="80" />
+      </template>
+    </Placeholder>
+  </div>
+</template>
+
+<style scoped>
+.start-page {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 100%;
+}
+</style>


### PR DESCRIPTION
## Summary
- add Start.vue page introducing the app
- route root path to the new start screen
- navigate back to `/home` from hotel and location screens

## Testing
- `yarn lint` *(fails: existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68754d68a2588322a7b0c9ed7daf7ae1