### PR TITLE
Add transport filter

### DIFF
--- a/client/src/domain/entities/TripDetails.ts
+++ b/client/src/domain/entities/TripDetails.ts
@@ -38,4 +38,9 @@ export default interface TripDetails {
    * Maximum travel time to the club in minutes
    */
   maxTravelTime: number;
+
+  /**
+   * Preferred transportation method
+   */
+  transport: 'walking' | 'car';
 }

--- a/client/src/domain/services/useTripDetails.ts
+++ b/client/src/domain/services/useTripDetails.ts
@@ -54,6 +54,11 @@ interface useTripDetailsComposableState {
   setMaxTravelTime: (time: TripDetails['maxTravelTime']) => void;
 
   /**
+   * Sets preferred transport type
+   */
+  setTransport: (transport: TripDetails['transport']) => void;
+
+  /**
    * Information about current trip
    */
   trip: UnwrapNestedRefs<TripDetails>;
@@ -88,6 +93,7 @@ const trip = reactive<TripDetails>({
   room: 0,
   directions: [],
   maxTravelTime: 30,
+  transport: 'walking',
 })
 
 /**
@@ -149,6 +155,10 @@ export const useTripDetails = createSharedComposable((): useTripDetailsComposabl
     trip.maxTravelTime = time
   }
 
+  function setTransport(transport: TripDetails['transport']): void {
+    trip.transport = transport
+  }
+
   /**
    * Currently selected location based on trip details
    */
@@ -192,6 +202,7 @@ export const useTripDetails = createSharedComposable((): useTripDetailsComposabl
     setRoom,
     setDirections,
     setMaxTravelTime,
+    setTransport,
     trip,
     location,
     selectDefault,


### PR DESCRIPTION
## Summary
- extend trip details with transport option
- support transportation selection in trip details service
- add transport filter UI with dropdown

## Testing
- `yarn lint` *(fails: Too many blank lines, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_687605eddbe88322b4dbd9ffa2717b43