### PR TITLE
Improve travel time filter

### DIFF
--- a/client/src/presentation/components/Slider/Slider.vue
+++ b/client/src/presentation/components/Slider/Slider.vue
@@ -5,8 +5,8 @@ const props = withDefaults(defineProps<{
   max?: number;
   step?: number;
 }>(), {
-  min: 0,
-  max: 60,
+  min: 5,
+  max: 65,
   step: 5,
 })
 
@@ -28,5 +28,51 @@ defineEmits(['update:modelValue'])
 <style scoped>
 .slider {
   width: 100%;
+  -webkit-appearance: none;
+  background: transparent;
+  height: 30px;
+  position: relative;
+}
+
+.slider::-webkit-slider-runnable-track {
+  width: 100%;
+  height: 2px;
+  background: var(--color-bg-tertiary);
+}
+
+.slider::-moz-range-track {
+  width: 100%;
+  height: 2px;
+  background: var(--color-bg-tertiary);
+}
+
+.slider::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  height: 16px;
+  width: 16px;
+  background: var(--color-link);
+  border-radius: 50%;
+  margin-top: -7px;
+}
+
+.slider::-moz-range-thumb {
+  height: 16px;
+  width: 16px;
+  background: var(--color-link);
+  border-radius: 50%;
+  border: none;
+}
+
+.slider {
+  background-image: repeating-linear-gradient(
+    to right,
+    var(--color-bg-tertiary) 0,
+    var(--color-bg-tertiary) 1px,
+    transparent 1px,
+    transparent calc(100% / 12)
+  );
+  background-position: center;
+  background-repeat: no-repeat;
+  background-size: 100% 2px;
 }
 </style>

--- a/client/src/presentation/screens/Home.vue
+++ b/client/src/presentation/screens/Home.vue
@@ -23,7 +23,9 @@ const directionsLabel = computed(() => {
   return trip.directions.length > 0 ? `${trip.directions.length} selected` : 'Any'
 })
 
-const travelTimeLabel = computed(() => `${trip.maxTravelTime} min`)
+const travelTimeLabel = computed(() => {
+  return trip.maxTravelTime >= 65 ? 'Не важно' : `${trip.maxTravelTime} min`
+})
 
 const transportLabel = computed(() => trip.transport === 'walking' ? 'Пешком' : 'На машине')
 
@@ -366,30 +368,16 @@ onBeforeUnmount(() => {
             to="/directions"
           />
           <ListItem
-            label="Max travel time"
-            right-icon="chevron-right"
-            :right-icon-label="travelTimeLabel"
-            @click="onTimeClick"
-          />
-          <ListItemExpandable :opened="timePickerShowed">
-            <div ref="timePicker">
-              <Slider
-                :model-value="trip.maxTravelTime"
-                :min="0"
-                :max="60"
-                :step="5"
-                @update:model-value="setMaxTravelTime"
-              />
-            </div>
-          </ListItemExpandable>
-          <ListItem
             label="Как добираться"
             right-icon="chevron-right"
             :right-icon-label="transportLabel"
             @click="onTransportClick"
           />
           <ListItemExpandable :opened="transportPickerShowed">
-            <div ref="transportPicker" class="transport-picker">
+            <div
+              ref="transportPicker"
+              class="transport-picker"
+            >
               <button
                 :class="{ selected: trip.transport === 'walking' }"
                 @click="selectTransport('walking')"
@@ -402,6 +390,26 @@ onBeforeUnmount(() => {
               >
                 На машине
               </button>
+            </div>
+          </ListItemExpandable>
+          <ListItem
+            label="Max travel time"
+            right-icon="chevron-right"
+            :right-icon-label="travelTimeLabel"
+            @click="onTimeClick"
+          />
+          <ListItemExpandable :opened="timePickerShowed">
+            <div
+              ref="timePicker"
+              class="time-picker"
+            >
+              <Slider
+                :model-value="trip.maxTravelTime"
+                :min="5"
+                :max="65"
+                :step="5"
+                @update:model-value="setMaxTravelTime"
+              />
             </div>
           </ListItemExpandable>
         </List>
@@ -614,6 +622,10 @@ onBeforeUnmount(() => {
 
 .results {
   min-height: 800px;
+}
+
+.time-picker {
+  padding: 15px var(--size-cell-h-padding);
 }
 
 .transport-picker {


### PR DESCRIPTION
## Summary
- swap order of transport and travel time filters
- style max travel time slider with ticks
- add "not important" label when slider maxed
- add padding for travel time dropdown

## Testing
- `yarn lint` *(fails: ESLint config invalid)*

------
https://chatgpt.com/codex/tasks/task_e_68769cb229848322af84a398025d0218